### PR TITLE
Ensure Jamulus starts at (re)boot

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,4 +4,5 @@
     daemon_reload: true
     name: "{{ jamulus_service }}"
     state: restarted
+    enabled: true
   become: true


### PR DESCRIPTION
The docs at https://docs.ansible.com/ansible/latest/collections/ansible/builtin/systemd_module.html say one or more from `enabled` and `state` are possible.
I found after building an AMI the service was stopped somehow, so I think this should ensure it comes up again after boot.